### PR TITLE
Add title and controls to index page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
   </script>
 </head>
 <body>
+  <h1>Zombie Game</h1>
   <script type="module" src="./game/Main.js"></script>
 </body>
 </html>

--- a/ts/game/Main.ts
+++ b/ts/game/Main.ts
@@ -11,6 +11,20 @@ const levelOrder = ['1', '2', '3', 'b'];
 const app = new PIXI.Application({ width: 600, height: 500, backgroundColor: 0x000000 });
 document.body.appendChild(app.view as HTMLCanvasElement);
 
+const info = document.createElement('div');
+info.id = 'info';
+info.innerHTML = `
+  <p><a href="https://github.com/brandonpickering/zombie-game">Source on GitHub</a></p>
+  <h2>Controls</h2>
+  <ul>
+    <li>ASDW to move.</li>
+    <li>Left click to shoot.</li>
+    <li>Right click or space to stab.</li>
+    <li><b>Debug:</b> Press 1-4 to switch level.</li>
+  </ul>
+`;
+document.body.appendChild(info);
+
 Camera.init(app);
 TextureManager.loadTextures();
 FontManager.loadFonts();


### PR DESCRIPTION
## Summary
- Show game title on index page
- Move info section into script so it renders under the JS-created canvas, marking level switching as a debug control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68942ff824dc8320b8e8ab22699720a5