### PR TITLE
Fix GPU memory leak by reusing text objects

### DIFF
--- a/ts/game/Game.ts
+++ b/ts/game/Game.ts
@@ -10,6 +10,8 @@ export class Game {
   paused = false;
   private levelOrder: string[] = [];
   private keySprite: PIXI.Sprite = new PIXI.Sprite(TextureManager.KEY);
+  private healthText: PIXI.Text = new PIXI.Text('', FontManager.DISPLAY);
+  private ammoText: PIXI.Text = new PIXI.Text('', FontManager.DISPLAY);
 
   constructor(levels: string[], private world: PIXI.Container) {
     this.levelOrder = [...levels];
@@ -73,19 +75,13 @@ export class Game {
       ui.addChild(this.keySprite);
       healthX = 45; // offset to avoid overlapping the key icon
     }
-    const healthText = new PIXI.Text(
-      `Health: ${this.level.player.health}`,
-      FontManager.DISPLAY
-    );
-    healthText.x = healthX;
-    healthText.y = Camera.height - healthText.height;
-    ui.addChild(healthText);
-    const ammoText = new PIXI.Text(
-      `Ammo: ${this.level.player.ammo}`,
-      FontManager.DISPLAY
-    );
-    ammoText.x = Camera.width - ammoText.width;
-    ammoText.y = Camera.height - ammoText.height;
-    ui.addChild(ammoText);
+    this.healthText.text = `Health: ${this.level.player.health}`;
+    this.healthText.x = healthX;
+    this.healthText.y = Camera.height - this.healthText.height;
+    ui.addChild(this.healthText);
+    this.ammoText.text = `Ammo: ${this.level.player.ammo}`;
+    this.ammoText.x = Camera.width - this.ammoText.width;
+    this.ammoText.y = Camera.height - this.ammoText.height;
+    ui.addChild(this.ammoText);
   }
 }

--- a/ts/game/level/Level.ts
+++ b/ts/game/level/Level.ts
@@ -57,7 +57,10 @@ export class Level {
           this.didDie = true;
         }
         const disp = this.creatures[i].display;
-        if (disp && disp.parent) disp.parent.removeChild(disp);
+        if (disp && disp.parent) {
+          disp.parent.removeChild(disp);
+          if (typeof (disp as any).destroy === 'function') (disp as any).destroy();
+        }
         this.creatures.splice(i, 1);
         i--;
       }
@@ -83,10 +86,11 @@ export class Level {
       }
       if (!struck) {
         const tile = this.tileGrid.getTile(b.pos);
-        if (tile && this.tileGrid.tiles[tile[0]][tile[1]]) struck = true;
+        if (!tile || this.tileGrid.tiles[tile[0]][tile[1]]) struck = true;
       }
       if (struck) {
         if (b.graphics.parent) b.graphics.parent.removeChild(b.graphics);
+        b.graphics.destroy();
         this.bullets.splice(i, 1);
         i--;
       }
@@ -108,6 +112,7 @@ export class Level {
       if (pickedUp) {
         if (item.display && item.display.parent) {
           item.display.parent.removeChild(item.display);
+          if (typeof (item.display as any).destroy === 'function') (item.display as any).destroy();
         }
         this.items.splice(i, 1);
         i--;


### PR DESCRIPTION
## Summary
- destroy PIXI display objects when creatures die or items are collected
- remove off-screen bullets and destroy their graphics to prevent leaks
- reuse UI text objects instead of creating new ones each frame

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894394bb2948320ac6f855d0fcf15e6